### PR TITLE
Add pypiwin32 as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,8 @@ setup(
     author = "Luke McCarthy",
     author_email = "luke@iogopro.co.uk",
     url = "http://github.com/shaurz/fsmonitor",
+    install_requires=[
+        'pypiwin32',
+    ],
     packages = ["fsmonitor"],
 )


### PR DESCRIPTION
This package uses pypiwin32 as a dependency and doesn't list it on the setup.py, so now running this without pypiwin32 being installed results in an `ImportError`.