### PR TITLE
Check for platform with `sys.platform.startswith`

### DIFF
--- a/fsmonitor/__init__.py
+++ b/fsmonitor/__init__.py
@@ -17,7 +17,7 @@ from .common import FSEvent, FSMonitorError, FSMonitorOSError
 # set to None when unloaded
 module_loaded = True
 
-if sys.platform == "linux2":
+if sys.platform.startswith("linux"):
     from .linux import FSMonitor
 elif sys.platform == "win32":
     from .win32 import FSMonitor


### PR DESCRIPTION
This works for linux versions 3.x and 4.x and in Python 3.3+, where Linux major version is no longer appended to `sys.platform`.